### PR TITLE
fix: nix package build and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ dist-ssr
 *.sln
 *.sw?
 docs/*.md
+
+.devenv*
+.direnv
+.envrc
+devenv.*
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -44,8 +44,9 @@ let
         "target"
       ]);
   };
-  manifest = builtins.fromTOML (builtins.readFile ../src-tauri/Cargo.toml);
+  manifest = fromTOML (builtins.readFile ../src-tauri/Cargo.toml);
 
+  # similar to https://github.com/NixOS/nixpkgs/blob/2fcb964de67fcf60b43471c55d5d99e61a9ccb5a/pkgs/by-name/mo/modrinth-app/package.nix#L54
   runtimeDependencies = lib.optionalString stdenv.hostPlatform.isLinux (
     lib.makeLibraryPath [
       addDriverRunpath.driverLink
@@ -81,7 +82,6 @@ rustPlatform.buildRustPackage {
   src = source;
 
   postPatch = ''
-    # replace bun run build:frontend with npm run build:frontend in src-tauri/tauri.conf.json
     substituteInPlace src-tauri/tauri.conf.json \
       --replace 'bun run build:frontend' 'npm run build:frontend'
   '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,6 +26,7 @@
   libpulseaudio,
   pipewire,
   udev,
+  wayland,
   buildChannel ? "release",
 }:
 
@@ -58,6 +59,7 @@ let
       libxext
       libxrandr
       libxxf86vm
+      wayland
 
       # lwjgl
       (lib.getLib stdenv.cc.cc)
@@ -114,17 +116,11 @@ rustPlatform.buildRustPackage {
 
   doCheck = false;
 
-  postInstall = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     gappsWrapperArgs+=(
-      ${lib.optionalString stdenv.hostPlatform.isLinux ''
-        --set LD_LIBRARY_PATH ${runtimeDependencies}
-        --set __NV_DISABLE_EXPLICIT_SYNC 1
-      ''}
+      --set LD_LIBRARY_PATH ${runtimeDependencies}
+      --set __NV_DISABLE_EXPLICIT_SYNC 1
     )
-
-    glibPostInstallHook
-    gappsWrapperArgsHook
-    wrapGApp "$out/bin/basalt-launcher"
   '';
 
   meta = {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,39 +4,87 @@
   importNpmLock,
   nodejs,
   pkg-config,
-  wrapGAppsHook3,
-  makeDesktopItem,
-  copyDesktopItems,
+  wrapGAppsHook4,
   glib-networking,
-  gtk3,
-  libayatana-appindicator,
-  librsvg,
+  cacert,
+  npmHooks,
+  cargo-tauri,
   openssl,
+  stdenv,
   webkitgtk_4_1,
+  gsettings-desktop-schemas,
+  addDriverRunpath,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  flite,
+  alsa-lib,
+  libjack2,
+  libpulseaudio,
+  pipewire,
+  udev,
   buildChannel ? "release",
 }:
 
 let
   source = lib.cleanSourceWith {
     src = ../.;
-    filter = path: type:
-      let name = baseNameOf path;
-      in !(builtins.elem name [ ".git" "dist" "node_modules" "target" ]);
+    filter =
+      path: type:
+      let
+        name = baseNameOf path;
+      in
+      !(builtins.elem name [
+        ".git"
+        "dist"
+        "node_modules"
+        "target"
+      ]);
   };
   manifest = builtins.fromTOML (builtins.readFile ../src-tauri/Cargo.toml);
-  desktopItem = makeDesktopItem {
-    name = "basalt-launcher";
-    desktopName = "Basalt Launcher";
-    comment = "A polished Minecraft launcher";
-    exec = "basalt-launcher";
-    icon = "basalt-launcher";
-    categories = [ "Game" ];
-  };
+
+  runtimeDependencies = lib.optionalString stdenv.hostPlatform.isLinux (
+    lib.makeLibraryPath [
+      addDriverRunpath.driverLink
+
+      # glfw
+      libGL
+      libx11
+      libxcursor
+      libxext
+      libxrandr
+      libxxf86vm
+
+      # lwjgl
+      (lib.getLib stdenv.cc.cc)
+
+      # narrator support
+      flite
+
+      # openal
+      alsa-lib
+      libjack2
+      libpulseaudio
+      pipewire
+
+      # oshi
+      udev
+    ]
+  );
 in
 rustPlatform.buildRustPackage {
   pname = if buildChannel == "dev" then "basalt-launcher-dev" else "basalt-launcher";
   inherit (manifest.package) version;
   src = source;
+
+  postPatch = ''
+    # replace bun run build:frontend with npm run build:frontend in src-tauri/tauri.conf.json
+    substituteInPlace src-tauri/tauri.conf.json \
+      --replace 'bun run build:frontend' 'npm run build:frontend'
+  '';
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri";
@@ -45,37 +93,39 @@ rustPlatform.buildRustPackage {
   npmDeps = importNpmLock { npmRoot = source; };
 
   nativeBuildInputs = [
+    cacert
+    cargo-tauri.hook
     nodejs
     pkg-config
-    wrapGAppsHook3
-    copyDesktopItems
     importNpmLock.npmConfigHook
+    npmHooks.npmInstallHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    glib-networking
-    gtk3
-    libayatana-appindicator
-    librsvg
     openssl
     webkitgtk_4_1
+    glib-networking
+    gsettings-desktop-schemas
   ];
 
   BASALT_BUILD_CHANNEL = buildChannel;
   BASALT_DISTRIBUTION = "nix";
 
-  preBuild = ''
-    npm run build:frontend
-  '';
-
   doCheck = false;
 
   postInstall = ''
-    install -Dm644 src-tauri/icons/128x128.png \
-      "$out/share/icons/hicolor/128x128/apps/basalt-launcher.png"
-  '';
+    gappsWrapperArgs+=(
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --set LD_LIBRARY_PATH ${runtimeDependencies}
+        --set __NV_DISABLE_EXPLICIT_SYNC 1
+      ''}
+    )
 
-  desktopItems = [ desktopItem ];
+    glibPostInstallHook
+    gappsWrapperArgsHook
+    wrapGApp "$out/bin/basalt-launcher"
+  '';
 
   meta = {
     description = "A polished Minecraft launcher with practical instance and content management";


### PR DESCRIPTION
<!--
Use a Conventional Commit title, for example:
feat(ui): add loader filters to discovery
fix(core): preserve native libraries in inherited versions
-->

## Summary

<!-- What changed? Keep this focused on the behavior reviewers need to understand. -->
Fix the nix build process and dependencies required to run Minecraft instances and the launcher itself.

## Why

<!-- What problem does this solve, and why is this the right approach for Basalt? -->
The current nix package shows an error: `Could not connect to localhost: Connection refused`

## Testing

<!-- List the commands and manual workflows you used. Include Minecraft versions, loaders, and platforms when relevant. -->

- [x] `nix build .` `./result/bin/basalt-launcher`
- [x] Create and run both modded and unmodded instances

## Checklist

- [x] I reviewed the complete diff and removed unrelated changes.
- [x] I tested the affected workflow in the application.
- [x] I followed the existing Rust, React, state, and IPC patterns.
- [x] I updated types, command registration, and callers for any IPC contract change.
- [x] I added or updated tests where the changed behavior can be tested reliably.
- [x] I updated documentation when setup, behavior, or contributor expectations changed.
- [x] I did not include credentials, launcher data, build output, or debug code.
- [x] I directed and reviewed this work; it was not blindly or entirely delegated to AI.
- [x] I disclosed any material use of generated code in the summary.
